### PR TITLE
Fix guard_objc_util

### DIFF
--- a/_utils.py
+++ b/_utils.py
@@ -9,13 +9,12 @@ __copyright__ = "Copyright (c) 2016 Lukas Kollmer<lukas.kollmer@gmail.com>"
 try:
 	import objc_util
 	_HAS_OBJC_UTIL = True
+	_application = objc_util.UIApplication.sharedApplication()
 except:
 	_HAS_OBJC_UTIL = False
 
-_application = objc_util.UIApplication.sharedApplication()
-
 def guard_objc_util():
-	if not _HAS_OBJC_UTIL: raise NameError("objc_util not available")
+	if not _HAS_OBJC_UTIL: raise ImportError("objc_util not available")
 
 def add_method(method, cls):
 	guard_objc_util()


### PR DESCRIPTION
It wasn't doing much before. Also use more appropriate exception class.

Really, though, the method is sort of pointless. Why not just let Python throw an error? You're not doing anything different than Python does. Python will throw an error if you try to import an unavailable module, why catch it only to raise a slightly different (and before this PR, a less appropriate) one?
